### PR TITLE
EndScreen Activity ausprogrammiert

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,7 +29,11 @@
         <activity
             android:name=".QuestionActivity"
             android:parentActivityName=".MainActivity"
-            android:screenOrientation="landscape" ></activity>
+            android:screenOrientation="landscape" />
+        <activity android:name=".EndScreenActivity"
+            android:screenOrientation="portrait"
+            >
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/at/technikum_wien/cheers/EndScreenActivity.java
+++ b/app/src/main/java/at/technikum_wien/cheers/EndScreenActivity.java
@@ -1,0 +1,29 @@
+package at.technikum_wien.cheers;
+
+import android.content.Intent;
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+import android.view.View;
+import android.view.Window;
+import android.view.WindowManager;
+
+public class EndScreenActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_end_screen);
+    }
+
+    public void restartGame(View view){
+        Intent intent = new Intent(this, PlayerActivity.class);
+        startActivity(intent);
+    }
+
+    public void homeButton(View view){
+        Intent intent = new Intent(this, MainActivity.class);
+        intent.putExtra("intentFromEndScreen",true);
+        startActivity(intent);
+    }
+
+}

--- a/app/src/main/java/at/technikum_wien/cheers/MainActivity.java
+++ b/app/src/main/java/at/technikum_wien/cheers/MainActivity.java
@@ -20,11 +20,10 @@ import android.widget.Toast;
 
 //Startbildschirm
 
-public class MainActivity extends AppCompatActivity implements View.OnClickListener{
+public class MainActivity extends AppCompatActivity implements View.OnClickListener {
 
     private Button buttonPlay, buttonSettings, buttonMore;
     private TextView tvLastUpdate;
-
 
 
     @Override
@@ -35,11 +34,22 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         ###Hier wird der Warndialog gezeigt
         ###Wenn man Schliessen oder daneben drückt, wird die Activity gekillt,
         ###Klickt man auf Spielen, wird ganz normal fortgefahren im Code
+        #
+        #Dieser Dialog wird nur angezeigt, wenn die App startet, wenn man das Spiel durchspielt,
+        #und man auf Home drückt, soll dieser Dialog nicht gezeigt werden
+        #
+        #ToDo 1: Wenn man innerhalb der App in der Action bar navigiert, wird der Dialog auch angezeigt,
+        #ToDo 2: beim Drücken des zurück Buttons am Handy wirds nicht angezeigt.. Aber die Action bar wird eh ausgeblendet
+        #
+        #
+        #
         #####################################################################*/
-
-        // WarningDialogFragment warningDialog= new WarningDialogFragment();
-       // warningDialog.show(getFragmentManager(), "warning");
-
+        /*
+        if(!(getIntent().hasExtra("intentFromEndScreen"))){
+            WarningDialogFragment warningDialog= new WarningDialogFragment();
+            warningDialog.show(getFragmentManager(), "warning");
+        }
+        */
 
 
         //Remove title bar
@@ -49,22 +59,22 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         setContentView(R.layout.activity_main);
 
         //GetSetButtons
-        buttonPlay = (Button)findViewById(R.id.menue_play_button);
-        buttonSettings = (Button)findViewById(R.id.menue_settings_button);
-        buttonMore = (Button)findViewById(R.id.menue_more_button);
+        buttonPlay = (Button) findViewById(R.id.menue_play_button);
+        buttonSettings = (Button) findViewById(R.id.menue_settings_button);
+        buttonMore = (Button) findViewById(R.id.menue_more_button);
         buttonPlay.setOnClickListener(this);
         buttonSettings.setOnClickListener(this);
         buttonMore.setOnClickListener(this);
 
         //GetSetTV (hier würde ich immer einfach einen "Timestamp" reinhauen, wann die neueste DB gedownloaded wurde)
-        tvLastUpdate = (TextView)findViewById(R.id.lastUpdate_tv);
+        tvLastUpdate = (TextView) findViewById(R.id.lastUpdate_tv);
         tvLastUpdate.setText("Noch nie");
     }
 
     @Override
     public void onClick(View view) {
         Intent intent;
-        switch (view.getId()){
+        switch (view.getId()) {
             case R.id.menue_play_button:
                 intent = new Intent(this, PlayerActivity.class);
                 startActivity(intent);
@@ -74,6 +84,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                 startActivity(intent);
                 break;
             case R.id.menue_more_button:
+
+                //Test for Endscreen
+                //ToDo: Delete after testing
+                intent = new Intent(this, EndScreenActivity.class);
+                startActivity(intent);
+
+
                 break;
             default:
                 break;

--- a/app/src/main/java/at/technikum_wien/cheers/QuestionActivity.java
+++ b/app/src/main/java/at/technikum_wien/cheers/QuestionActivity.java
@@ -67,7 +67,8 @@ public class QuestionActivity extends AppCompatActivity implements View.OnClickL
             setQuestionTv(currentRound - 1);
             setRoundsTv();
         }else{
-            //Hier fehlt noch ein Intent zu dem EndScreen
+            Intent intent = new Intent(this, EndScreenActivity.class);
+            startActivity(intent);
         }
     }
 

--- a/app/src/main/java/at/technikum_wien/cheers/WarningDialogFragment.java
+++ b/app/src/main/java/at/technikum_wien/cheers/WarningDialogFragment.java
@@ -5,6 +5,7 @@ import android.app.Dialog;
 import android.app.DialogFragment;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.os.SystemClock;
 
 /**
  * Created by Alexander on 03.01.2018.
@@ -31,6 +32,7 @@ public class WarningDialogFragment extends DialogFragment{
                     public void onClick(DialogInterface dialog, int id) {
                         // Die app schließt sich
                         getActivity().finish();
+
                     }
                 });
         // Create the AlertDialog object and return it

--- a/app/src/main/res/layout/activity_end_screen.xml
+++ b/app/src/main/res/layout/activity_end_screen.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center"
+    >
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:text="@string/endScreenTitle"
+        android:textSize="50sp"
+        android:textStyle="bold"
+        android:paddingBottom="40dp"/>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/endScreenMessage"
+        android:paddingLeft="20dp"
+        android:paddingRight="20dp"
+        android:textSize="20sp"
+        android:textAlignment="center"/>
+
+    <Button
+
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/endScreenButtonRestart"
+        android:layout_marginTop="20dp"
+        android:onClick="restartGame"
+        />
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/endScreenButtonHome"
+        android:layout_marginTop="20dp"
+        android:onClick="homeButton"
+       />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,4 +14,8 @@
     <string name="warningDialogTitle">Warnhinweis</string>
     <string name="warningDialogPositiveButton">Spielen</string>
     <string name="warningDialogNegativeButton">Schließen</string>
+    <string name="endScreenTitle">Ende</string>
+    <string name="endScreenMessage">Bravo! Ihr habt Cheers erfolgreich beendet. Wenn Ihr noch immer nicht genug vom Alkohol habt, dann drückt Restart!</string>
+    <string name="endScreenButtonHome">HOME</string>
+    <string name="endScreenButtonRestart">RESTART</string>
 </resources>


### PR DESCRIPTION
Warndialog aktualisiert, wenn man vom Endscreen wieder zur MainActivity will, wird der Dialog nicht angezeigt

Nach allen Runden wird in die Endscreenactivity gewechselt